### PR TITLE
fix: linux installation command

### DIFF
--- a/source/installation/20-install-on-linux-x86-64.md
+++ b/source/installation/20-install-on-linux-x86-64.md
@@ -4,7 +4,7 @@ NodeX officially provides pre-built binaries for the x86_64 architecture Linux.
 
 ```bash
 % curl -OL https://github.com/nodecross/nodex/releases/latest/download/nodex-agent-x86_64.zip
-% unzip nodex-agent-mac.zip
+% unzip nodex-agent-x86_64.zip
 % install nodex-agent
 % nodex-agent --version
 ```


### PR DESCRIPTION
Found this typo `unzip nodex-agent-mac.zip`, the correct command should be `unzip nodex-agent-x86_64.zip`